### PR TITLE
Remove colon here

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,8 +3,8 @@ layout: lesson
 root: .
 ---
 This Library Carpentry lesson introduces librarians to working with data in OpenRefine.
-At the conclusion of the lesson you will:
-understand what the OpenRefine software does;
+At the conclusion of the lesson you will
+understand what the OpenRefine software does and how to
 use the OpenRefine software to work with data files.
 
 > ## Prerequisites


### PR DESCRIPTION
The colon here is after a sentence fragment. I rewrote the sentences without the colon.

Please delete the text below before submitting your contribution. 

---

